### PR TITLE
🚨 badge to show build number in github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Run Playwright and Deploy Allure Report to GitHub Pages
-
+run-name: "${{ github.ref_name }}_${{ github.run_id }}_${{ github.run_attempt }}"
 on:
   push:
     branches:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Get Build Number
+        run: echo "Build #${{ github.run_number }}" > build-number-run.txt  
+
       - name: Run Codacy analysis
         env:
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
@@ -111,7 +114,13 @@ jobs:
       # ✅ Build Angular with Allure Report inside
       - name: Build Angular app
         run: npm run build -- --base-href=/angular-playwright-e2e/
-
+      
+      # ✅ Upload  Build number to GitHub Pages
+      - name: Prepare build runner artifacts
+        run: |
+         # Create a build-number.txt file with the GitHub run number
+         echo "Build #${{ github.run_number }}" > ./dist/angular-playwright-e2e/browser/build-number.txt
+  
       # ✅ Copy Allure Report to Angular build folder
       - name: Copy Allure Report to GitHub Pages
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,28 @@
 name: Playwright E2E Tests (Only on Manual Run)
+run-name: "${{ inputs.deployment-environment }}: ${{ inputs.build-number }}"
 
 on:
    workflow_dispatch:
+     inputs:
+      build-number:
+        description: Build number to deploy
+        required: true
+        type: string
+      deployment-environment:
+        required: true
+        description: Deployment environment
+        type: choice
+        options:
+          - development
+          - test
+          - production
+
+permissions:
+  contents: read
+  id-token: write
+
+# Prevent multiple run to the same deployment environment from running at the same time.
+concurrency: ${{ inputs.deployment-environment }}-e2e-tests
 
 jobs:
   e2e-tests:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Get Build Number
+        run: echo "Build #${{ github.run_number }}" > build-number-test.txt   
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,0 +1,32 @@
+name: Update Build Badge
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1️⃣ Checkout repository
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      # 2️⃣ Update README badge with latest run number
+      - name: Update README build number
+        run: |
+          BUILD_NUMBER=${{ github.run_number }}
+          echo "Updating README badge to build #$BUILD_NUMBER"
+          sed -i "s/#BUILD_NUMBER/$BUILD_NUMBER/g" README.md
+
+      # 3️⃣ Commit & push changes
+      - name: Commit changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update build badge to #${{ github.run_number }}" || echo "No changes to commit"
+          git push

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,32 @@
+name: Update README with Build Number
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1️⃣ Checkout the repo
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # 2️⃣ Replace placeholder with latest GitHub run number
+      - name: Update README
+        run: |
+          BUILD_NUMBER=${{ github.run_number }}
+          echo "Updating README with build #$BUILD_NUMBER"
+          sed -i "s/#PLACEHOLDER/$BUILD_NUMBER/g" README.md
+
+      # 3️⃣ Commit and push changes
+      - name: Commit changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update build number to #${{ github.run_number }}" || echo "No changes to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -43,6 +43,45 @@ ng g m app-routing --flat --module=app
 npx playwright show-trace test-results/<your-test-folder>/trace.zip
 
 
+## badges/shields in github actions
+(main_14104423181_1) is the GitHub Actions run name.
+
+⚡ But here’s the difference vs Bamboo:
+
+Bamboo badges let you display a specific build number (483-master+483, etc.).
+
+GitHub’s native workflow badge only shows status (passing / failing), not the run name or run number.
+
+
+✅ 1. Build / Test Status Badges
+
+[![Build](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/deploy.yml/badge.svg)](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/deploy.yml)
+[![Tests](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/playwright.yml/badge.svg)](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/playwright.yml)
+
+✅ 2. Environment Deploy Badges
+
+Option A: Separate Workflows Per Environment
+
+[![Dev Deploy](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/deploy.yml/badge.svg)](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/workflows/deploy.yml)
+
+Option B: Single Workflow with Multiple Jobs
+
+![Dev Deploy Tests](https://img.shields.io/github/actions/workflow/status/sanjeetkumaritoutlook/angular-playwright-e2e/playwright.yml?branch=main&event=workflow_dispatch&label=Playwright%20E2E%20Tests%20(Only%20on%20Manual%20Run))
+
+✅ 3. Build number Badges
+
+[![Build Number](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/sanjeetkumaritoutlook/angular-playwright-e2e/gh-pages/build-number.txt)](https://sanjeetkumaritoutlook.github.io/angular-playwright-e2e/build-number.txt)
+
+![Build Number semi-automatic](https://raw.githubusercontent.com/sanjeetkumaritoutlook/angular-playwright-e2e/main/build-number.txt)
+
+
+[Latest Build Number](https://github.com/sanjeetkumaritoutlook/angular-playwright-e2e/actions/runs/<RUN_ID>)
+
+Latest Build: **![Build](https://img.shields.io/badge/build-#PLACEHOLDER-blue)**
+
+![Build Badge](https://img.shields.io/badge/build-#BUILD_NUMBER-blue)
+
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.


### PR DESCRIPTION
(main_14104423181_1) is the GitHub Actions run name.

⚡ But here’s the difference vs Bamboo:

Bamboo badges let you display a specific build number (483-master+483, etc.).

GitHub’s native workflow badge only shows status (passing / failing), not the run name or run number.

